### PR TITLE
Remove DefineConstants tag from project file

### DIFF
--- a/Samples/BeanTrader/NetCore/BeanTraderClient/BeanTraderClient.Core.csproj
+++ b/Samples/BeanTrader/NetCore/BeanTraderClient/BeanTraderClient.Core.csproj
@@ -6,7 +6,6 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>BeanTraderClient</RootNamespace>
     <AssemblyName>BeanTraderClient</AssemblyName>
-    <DefineConstants>NETCORE</DefineConstants>
     <ApplicationIcon>BeanTrader.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/Samples/BeanTrader/NetCore/BeanTraderClient/Services/TradingService.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderClient/Services/TradingService.cs
@@ -33,11 +33,11 @@ namespace BeanTraderClient.Services
                     {
                         var newClient = ClientFactory.GetServiceClient();
                         await SetClientCredentialsAsync(newClient).ConfigureAwait(false);
-#if NETCORE
+#if NETCOREAPP
                         await newClient.OpenAsync().ConfigureAwait(false);
 #else
                         newClient.Open();
-#endif // NETCORE
+#endif // NETCOREAPP
                         client = newClient;
                     }
                 }
@@ -61,9 +61,9 @@ namespace BeanTraderClient.Services
             // Begin monitoring the connection for faults or disconnects
             Task.Run(() => CheckForHeartbeatAsync(CancellationSource.Token));
         }
-        
+
         public Task<bool> AcceptTradeAsync(Guid id) =>
-            SafeServiceCallAsync(async () => 
+            SafeServiceCallAsync(async () =>
             {
                 var client = await GetOrOpenClientAsync();
                 return await client.AcceptTradeAsync(id);


### PR DESCRIPTION
As shown in [Developing Libraries with Cross Platform Tools](https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget) SDK-style project automatically set MSBuild Compile constants based on the target framework.

As per the guidance referred to above, you should use the automatic `NETCOREAPP` constant for conditional compilation on .NET Core. Definining your own constants thus becomes unecessary.