### PR TITLE
Update BeanTraderServer in the NetCore folder to target .NET 6

### DIFF
--- a/Samples/.gitignore
+++ b/Samples/.gitignore
@@ -21,5 +21,6 @@ packages/
 
 # User-specific files
 .vs/
+.vscode/
 *.suo
 *.user

--- a/Samples/BeanTrader/NetCore/BeanTrader.sln
+++ b/Samples/BeanTrader/NetCore/BeanTrader.sln
@@ -1,11 +1,8 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28407.52
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BeanTraderServer", "BeanTraderServer\BeanTraderServer.csproj", "{C7FE70DF-EF5A-4FED-91BE-9F6488C17135}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BeanTraderClient", "BeanTraderClient\BeanTraderClient.csproj", "{995E758F-D656-4D2C-B679-69B81E58672F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BeanTraderCommon", "BeanTraderInterfaces\BeanTraderCommon.csproj", "{41C7E011-840E-44AB-9B5B-CAF6E7B7DE65}"
 EndProject
@@ -26,10 +23,6 @@ Global
 		{C7FE70DF-EF5A-4FED-91BE-9F6488C17135}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7FE70DF-EF5A-4FED-91BE-9F6488C17135}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7FE70DF-EF5A-4FED-91BE-9F6488C17135}.Release|Any CPU.Build.0 = Release|Any CPU
-		{995E758F-D656-4D2C-B679-69B81E58672F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{995E758F-D656-4D2C-B679-69B81E58672F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{995E758F-D656-4D2C-B679-69B81E58672F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{995E758F-D656-4D2C-B679-69B81E58672F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{41C7E011-840E-44AB-9B5B-CAF6E7B7DE65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{41C7E011-840E-44AB-9B5B-CAF6E7B7DE65}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41C7E011-840E-44AB-9B5B-CAF6E7B7DE65}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Samples/BeanTrader/NetCore/BeanTraderClient/BeanTraderCallback.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderClient/BeanTraderCallback.cs
@@ -3,11 +3,13 @@ using BeanTrader.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.ServiceModel;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace BeanTraderClient
 {
+    [CallbackBehavior(ConcurrencyMode = ConcurrencyMode.Multiple, UseSynchronizationContext = false)]
     public class BeanTraderCallback : BeanTraderServiceCallback
     {
         public event Action<TradeOffer> AddNewTradeOfferHandler;

--- a/Samples/BeanTrader/NetCore/BeanTraderClient/BeanTraderCallback.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderClient/BeanTraderCallback.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace BeanTraderClient
 {
-    [CallbackBehavior(ConcurrencyMode = ConcurrencyMode.Multiple, UseSynchronizationContext = false)]
     public class BeanTraderCallback : BeanTraderServiceCallback
     {
         public event Action<TradeOffer> AddNewTradeOfferHandler;

--- a/Samples/BeanTrader/NetCore/BeanTraderClient/ViewModels/TradingViewModel.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderClient/ViewModels/TradingViewModel.cs
@@ -49,7 +49,7 @@ namespace BeanTraderClient.ViewModels
             TradingService.Connected += LoadDataAsync;
 
             // Get initial trader info and trade offers
-            await LoadDataAsync().ConfigureAwait(false);
+            await LoadDataAsync().ConfigureAwait(true);
 
             // Register for service callbacks
             CallbackHandler.AddNewTradeOfferHandler += AddTradeOffer;
@@ -60,8 +60,8 @@ namespace BeanTraderClient.ViewModels
         public async Task UnloadAsync()
         {
             // Stop listening
-            await TradingService.StopListeningAsync().ConfigureAwait(false);
-            await TradingService.LogoutAsync().ConfigureAwait(false);
+            await TradingService.StopListeningAsync().ConfigureAwait(true);
+            await TradingService.LogoutAsync().ConfigureAwait(true);
 
             // Unregister for service callbacks
             CallbackHandler.AddNewTradeOfferHandler -= AddTradeOffer;
@@ -111,7 +111,7 @@ namespace BeanTraderClient.ViewModels
 
             if (!traderNames.TryGetValue(sellerId, out string traderName))
             {
-                var names = await TradingService.GetTraderNamesAsync(new Guid[] { sellerId }).ConfigureAwait(false);
+                var names = await TradingService.GetTraderNamesAsync(new Guid[] { sellerId }).ConfigureAwait(true);
 
                 traderName = names.ContainsKey(sellerId) ?
                     traderNames.AddOrUpdate(sellerId, names[sellerId], (g, s) => names[sellerId]) :
@@ -170,14 +170,14 @@ namespace BeanTraderClient.ViewModels
 
         private async Task UpdateTraderInfoAsync()
         {
-            CurrentTrader = await TradingService.GetCurrentTraderInfoAsync().ConfigureAwait(false);
+            CurrentTrader = await TradingService.GetCurrentTraderInfoAsync().ConfigureAwait(true);
         }
 
         private async Task LoadDataAsync()
         {
-            await LoginAsync().ConfigureAwait(false);
-            await UpdateTraderInfoAsync().ConfigureAwait(false);
-            await ListenForTradeOffersAsync().ConfigureAwait(false);
+            await LoginAsync().ConfigureAwait(true);
+            await UpdateTraderInfoAsync().ConfigureAwait(true);
+            await ListenForTradeOffersAsync().ConfigureAwait(true);
         }
 
         private Task LoginAsync()
@@ -219,8 +219,8 @@ namespace BeanTraderClient.ViewModels
         {
             if (offer.SellerId == CurrentTrader.Id)
             {
-                SetStatus($"Trade ({offer}) accepted by {await GetTraderNameAsync(buyerId).ConfigureAwait(false) ?? buyerId.ToString()}");
-                await UpdateTraderInfoAsync().ConfigureAwait(false);
+                SetStatus($"Trade ({offer}) accepted by {await GetTraderNameAsync(buyerId).ConfigureAwait(true) ?? buyerId.ToString()}");
+                await UpdateTraderInfoAsync().ConfigureAwait(true);
             }
         }
 
@@ -228,13 +228,13 @@ namespace BeanTraderClient.ViewModels
         {
             var ownTrade = tradeOffer.SellerId == CurrentTrader.Id;
             var success = ownTrade ?
-                await TradingService.CancelTradeOfferAsync(tradeOffer.Id).ConfigureAwait(false) :
-                await TradingService.AcceptTradeAsync(tradeOffer.Id).ConfigureAwait(false);
+                await TradingService.CancelTradeOfferAsync(tradeOffer.Id).ConfigureAwait(true) :
+                await TradingService.AcceptTradeAsync(tradeOffer.Id).ConfigureAwait(true);
 
             if (success)
             {
                 SetStatus($"{(ownTrade ? "Canceled" : "Accepted")} trade ({tradeOffer})");
-                await UpdateTraderInfoAsync().ConfigureAwait(false);
+                await UpdateTraderInfoAsync().ConfigureAwait(true);
             }
             else
             {
@@ -261,12 +261,12 @@ namespace BeanTraderClient.ViewModels
                 DataContext = newTradeOfferViewModel
             };
 
-            await DialogCoordinator.ShowMetroDialogAsync(this, newTradeDialog).ConfigureAwait(false);
+            await DialogCoordinator.ShowMetroDialogAsync(this, newTradeDialog).ConfigureAwait(true);
         }
 
         private async Task CreateTradeOfferAsync(TradeOffer tradeOffer)
         {
-            if (await TradingService.OfferTradeAsync(tradeOffer).ConfigureAwait(false) != Guid.Empty)
+            if (await TradingService.OfferTradeAsync(tradeOffer).ConfigureAwait(true) != Guid.Empty)
             {
                 SetStatus("New trade offer created");
             }
@@ -275,7 +275,7 @@ namespace BeanTraderClient.ViewModels
                 SetStatus("ERROR: Trade offer could not be created. Do you have enough beans?", Application.Current.FindResource("ErrorBrush") as Brush);
             }
 
-            await UpdateTraderInfoAsync().ConfigureAwait(false);
+            await UpdateTraderInfoAsync().ConfigureAwait(true);
         }
 
         private void SetStatus(string message) => SetStatus(message, Application.Current.FindResource("IdealForegroundColorBrush") as Brush);

--- a/Samples/BeanTrader/NetCore/BeanTraderInterfaces/BeanTraderCommon.csproj
+++ b/Samples/BeanTrader/NetCore/BeanTraderInterfaces/BeanTraderCommon.csproj
@@ -1,54 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{41C7E011-840E-44AB-9B5B-CAF6E7B7DE65}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BeanTraderInterfaces</RootNamespace>
     <AssemblyName>BeanTraderInterfaces</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Federation" Version="4.8.1" />
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.310801">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="IBeanTrader.cs" />
-    <Compile Include="IBeanTraderCallback.cs" />
-    <Compile Include="Models\Beans.cs" />
-    <Compile Include="Models\TradeOffer.cs" />
-    <Compile Include="Models\Trader.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/App.config
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/App.config
@@ -1,38 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <system.serviceModel>
-    <behaviors>
-      <serviceBehaviors>
-        <behavior name="beanTraderBehaviour">
-          <serviceMetadata httpGetEnabled="true" />
-          <serviceDebug includeExceptionDetailInFaults="true" />
-        </behavior>
-      </serviceBehaviors>
-    </behaviors>
-    <services>
-      <service name="BeanTraderServer.BeanTrader" behaviorConfiguration="beanTraderBehaviour">
-        <endpoint address="BeanTraderService" binding="netTcpBinding" bindingConfiguration="WindowsClient" contract="BeanTrader.IBeanTrader">
-        </endpoint>
-        <endpoint address="mex" binding="mexHttpBinding" contract="IMetadataExchange" />
-        <host>
-          <baseAddresses>
-            <!-- Requires: netsh http add urlacl url=http://+:8080/ user=REDMOND\mikerou -->
-            <add baseAddress="http://localhost:8080/" />
-            <add baseAddress="net.tcp://localhost:8090" />
-          </baseAddresses>
-        </host>
-      </service>
-    </services>
-    <bindings>
-      <netTcpBinding>
-        <binding name="WindowsClient">
-          <!-- Was going to use TransportWithMessageCredential security, but 
-               that is not yet supported on .NET Core. https://github.com/dotnet/wcf/issues/8 -->          
-          <security mode="Transport">
-            <transport clientCredentialType="Certificate" />
-          </security>
-        </binding>
-      </netTcpBinding>
-    </bindings>
-  </system.serviceModel>
 </configuration>

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/BeanTrader.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/BeanTrader.cs
@@ -1,12 +1,12 @@
 ﻿using BeanTrader;
 using BeanTrader.Models;
+using CoreWCF;
 using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using System.ServiceModel;
 using System.Text;
 using System.Threading;
 

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/BeanTraderServer.csproj
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/BeanTraderServer.csproj
@@ -1,72 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C7FE70DF-EF5A-4FED-91BE-9F6488C17135}</ProjectGuid>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RootNamespace>BeanTraderServer</RootNamespace>
-    <AssemblyName>BeanTraderServer</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BeanTrader.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="BeanTrader.pfx">
+    <None Update="BeanTrader.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\BeanTraderInterfaces\BeanTraderCommon.csproj">
-      <Project>{41C7E011-840E-44AB-9B5B-CAF6E7B7DE65}</Project>
-      <Name>BeanTraderCommon</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\BeanTraderInterfaces\BeanTraderCommon.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="CoreWCF.ConfigurationManager" Version="1.0.0" />
+    <PackageReference Include="CoreWCF.NetTcp" Version="1.0.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Federation" Version="4.8.1" />
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.310801">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/Program.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/Program.cs
@@ -1,31 +1,54 @@
-﻿using Serilog;
+﻿using CoreWCF.Configuration;
+using CoreWCF.Security;
+using Microsoft.AspNetCore.Builder;
+using Serilog;
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel;
-using System.ServiceModel.Security;
+using System.Threading.Tasks;
 
 namespace BeanTraderServer
 {
     class Program
     {
-        static void Main()
+        async static Task Main()
         {
             ConfigureLogging();
 
-            using (var host = new ServiceHost(typeof(BeanTrader)))
+            var builder = WebApplication.CreateBuilder();
+
+            // Set NetTcp port (previously this was done in configuration,
+            // but CoreWCF requires it be done in code)
+            builder.WebHost.UseNetTcp(8090);
+
+            // Add CoreWCF services to the ASP.NET Core app's DI container
+            builder.Services.AddServiceModelServices();
+            builder.Services.AddServiceModelConfigurationManagerFile("wcf.config");
+
+            var app = builder.Build();
+
+            // Configure CoreWCF endpoints in the ASP.NET Core host
+            app.UseServiceModel(serviceBuilder =>
             {
-                // For demo purposes, just load the key from disk so that no one needs to install an untrustworthy self-signed cert
-                // or load from KeyVault (which would complicate the sample)
-                var certPath = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BeanTrader.pfx");
-                host.Credentials.ServiceCertificate.Certificate = new X509Certificate2(certPath, "password");
-                host.Credentials.ClientCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;
-                host.Open();
-                Log.Information("Bean Trader Service listening");
-                WaitForExitSignal();
-                Log.Information("Shutting down...");
-                host.Close();
-            }
+                serviceBuilder.ConfigureServiceHostBase<BeanTrader>(beanTraderServiceHost =>
+                {
+                    // This code is copied from the old ServiceHost setup and configures
+                    // the local cert used for authentication.
+                    // For demo purposes, this just loads the certificate from disk so that no one needs to install an
+                    // untrustworthy self-signed cert or load from KeyVault (which would complicate the sample)
+                    var certPath = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BeanTrader.pfx");
+                    beanTraderServiceHost.Credentials.ServiceCertificate.Certificate = new X509Certificate2(certPath, "password");
+                    beanTraderServiceHost.Credentials.ClientCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;
+                });
+            });
+
+            await app.StartAsync();
+
+            Log.Information("Bean Trader Service listening");
+            WaitForExitSignal();
+            Log.Information("Shutting down...");
+
+            await app.StopAsync();
         }
 
         private static void WaitForExitSignal()

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/Program.cs
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/Program.cs
@@ -1,12 +1,9 @@
-﻿using BeanTrader;
-using CoreWCF;
-using CoreWCF.Configuration;
+﻿using CoreWCF.Configuration;
 using CoreWCF.Description;
 using CoreWCF.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Protocols.WsTrust;
 using Serilog;
 using System;
 using System.IO;

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/packages.config
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Serilog" version="2.8.0" targetFramework="net472" />
-  <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net472" />
-</packages>

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/wcf.config
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/wcf.config
@@ -3,14 +3,14 @@
   <system.serviceModel>
     <behaviors>
       <serviceBehaviors>
-        <behavior name="beanTraderBehaviour">
+        <behavior name="beanTraderBehavior">
           <serviceMetadata httpGetEnabled="true" />
           <serviceDebug includeExceptionDetailInFaults="true" />
         </behavior>
       </serviceBehaviors>
     </behaviors>
     <services>
-      <service name="BeanTraderServer.BeanTrader" behaviorConfiguration="beanTraderBehaviour">
+      <service name="BeanTraderServer.BeanTrader" behaviorConfiguration="beanTraderBehavior">
         <endpoint address="BeanTraderService" binding="netTcpBinding" bindingConfiguration="WindowsClient" contract="BeanTrader.IBeanTrader"></endpoint>
       </service>
     </services>

--- a/Samples/BeanTrader/NetCore/BeanTraderServer/wcf.config
+++ b/Samples/BeanTrader/NetCore/BeanTraderServer/wcf.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.serviceModel>
+    <behaviors>
+      <serviceBehaviors>
+        <behavior name="beanTraderBehaviour">
+          <serviceMetadata httpGetEnabled="true" />
+          <serviceDebug includeExceptionDetailInFaults="true" />
+        </behavior>
+      </serviceBehaviors>
+    </behaviors>
+    <services>
+      <service name="BeanTraderServer.BeanTrader" behaviorConfiguration="beanTraderBehaviour">
+        <endpoint address="BeanTraderService" binding="netTcpBinding" bindingConfiguration="WindowsClient" contract="BeanTrader.IBeanTrader"></endpoint>
+      </service>
+    </services>
+    <bindings>
+      <netTcpBinding>
+        <binding name="WindowsClient">
+          <security mode="Transport">
+            <transport clientCredentialType="Certificate" />
+          </security>
+        </binding>
+      </netTcpBinding>
+    </bindings>
+  </system.serviceModel>
+</configuration>


### PR DESCRIPTION
Use CoreWCF to upgrade the BeanTraderServer project in the NetCore (migrated) folder to target .NET 6. With this change, all projects int he NetCore folder target NetCore/Net6/NetStandard.